### PR TITLE
Fix include path and core count

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(ByteLiteSysDetect STATIC
 )
 
 target_include_directories(ByteLiteSysDetect PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )

--- a/src/ByteLiteSysDetect/ByteLiteSysDetect.cpp
+++ b/src/ByteLiteSysDetect/ByteLiteSysDetect.cpp
@@ -212,6 +212,7 @@ SystemInfo DetectSystem() {
     SystemInfo profile{};
     profile.cpuName = GetCPUName();
     profile.logicalThreads = GetLogicalThreads();
+    profile.coreCount = profile.logicalThreads;
     profile.physicalCores = GetPhysicalCores();
     profile.totalRAMBytes = GetRAMMB() * 1024 * 1024; // convert MB to bytes
     GetOSInfo(profile.osName, profile.osVersion);


### PR DESCRIPTION
## Summary
- expose root path for headers in CMake
- initialize coreCount when collecting system info

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`
